### PR TITLE
Pin version of the Docker image andy-model-assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 services:
   # Model data container (acts as a volume source)
   model-assets:
-    image: ghcr.io/rivoli-ai/andy-model-assets:latest
+    image: ghcr.io/rivoli-ai/andy-model-assets:v1
     command: ["true"]
     volumes:
       - model_data:/models


### PR DESCRIPTION
- Enforce the use of v1 when running `docker compose up`
- Ensure published packages to GHCR are tagged with commit shas ([see example](https://github.com/rivoli-ai/andy-inference-models/pkgs/container/andy-tokenizer-service/versions)) so we can pull the exact Docker images in other repos such as Andy Guard.